### PR TITLE
Convert PUT to POST

### DIFF
--- a/src/FetchWrapper.ts
+++ b/src/FetchWrapper.ts
@@ -436,7 +436,7 @@ export default class FetchWrapper {
          "/" +
          viewZUID +
          "?action=publish"
-      return await this.makeRequest(url, "PUT", payload)
+      return await this.makeRequest(url, "POST", payload)
    }
 
    // APP installations Section


### PR DESCRIPTION
It's unable to publish with a specific version in the params. To resolve it , it must be POST and also based on the documentation they use POST instead of PUT

Use POST instead of PUT
https://instances-api.zesty.org/#d87ea5b1-51e3-41f0-8814-78e89de7cb89